### PR TITLE
Fix return types for showShareSheet and generateShortUrl

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -282,11 +282,11 @@ interface BranchUniversalObject {
     shareOptions?: BranchShareSheetOptions,
     linkProperties?: BranchLinkProperties,
     controlParams?: BranchLinkControlParams
-  ) => void;
+  ) => Promise<{ channel: string; completed: boolean; error: boolean }>;
   generateShortUrl: (
     linkProperties: BranchLinkProperties,
     controlParams: BranchLinkControlParams
-  ) => void;
+  ) => Promise<{ url: string }>;
   logEvent: (eventName: string, params?: BranchEventParams) => Promise<null>;
   release: () => void;
 }


### PR DESCRIPTION
Updates return types for `showShareSheet` and `generateShortUrl` as requested:

https://github.com/BranchMetrics/react-native-branch-deep-linking-attribution/pull/612#issuecomment-748100711